### PR TITLE
Updated base URL for Toggl

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -2,33 +2,33 @@ from toggl.endpoints import Endpoints
 
 
 def test_static_endpoints():
-    assert Endpoints.WORKSPACES == "https://www.toggl.com/api/v8/workspaces"
-    assert Endpoints.CLIENTS == "https://www.toggl.com/api/v8/clients"
-    assert Endpoints.PROJECTS == "https://www.toggl.com/api/v8/projects"
-    assert Endpoints.REPORT_DETAILED == "https://toggl.com/reports/api/v2/details"
-    assert Endpoints.REPORT_SUMMARY == "https://toggl.com/reports/api/v2/summary"
-    assert Endpoints.START_TIME == "https://www.toggl.com/api/v8/time_entries/start"
-    assert Endpoints.TIME_ENTRIES == "https://www.toggl.com/api/v8/time_entries"
+    assert Endpoints.WORKSPACES == "https://api.track.toggl.com/api/v8/workspaces"
+    assert Endpoints.CLIENTS == "https://api.track.toggl.com/api/v8/clients"
+    assert Endpoints.PROJECTS == "https://api.track.toggl.com/api/v8/projects"
+    assert Endpoints.REPORT_DETAILED == "https://api.track.toggl.com/reports/api/v2/details"
+    assert Endpoints.REPORT_SUMMARY == "https://api.track.toggl.com/reports/api/v2/summary"
+    assert Endpoints.START_TIME == "https://api.track.toggl.com/api/v8/time_entries/start"
+    assert Endpoints.TIME_ENTRIES == "https://api.track.toggl.com/api/v8/time_entries"
     assert (
         Endpoints.CURRENT_RUNNING_TIME
-        == "https://www.toggl.com/api/v8/time_entries/current"
+        == "https://api.track.toggl.com/api/v8/time_entries/current"
     )
-    assert Endpoints.REPORT_WEEKLY == "https://toggl.com/reports/api/v2/weekly"
+    assert Endpoints.REPORT_WEEKLY == "https://api.track.toggl.com/reports/api/v2/weekly"
 
 
 def test_stop_time():
-    assert Endpoints.STOP_TIME(1) == "https://www.toggl.com/api/v8/time_entries/1/stop"
+    assert Endpoints.STOP_TIME(1) == "https://api.track.toggl.com/api/v8/time_entries/1/stop"
 
 
 def test_workspacde_projects():
     assert (
         Endpoints.WORKSPACE_PROJECTS(1)
-        == "https://www.toggl.com/api/v8/workspaces/1/projects"
+        == "https://api.track.toggl.com/api/v8/workspaces/1/projects"
     )
 
 
 def test_client_projects():
     assert (
         Endpoints.CLIENT_PROJECTS(1)
-        == "https://www.toggl.com/api/v8/clients/1/projects"
+        == "https://api.track.toggl.com/api/v8/clients/1/projects"
     )

--- a/toggl/endpoints.py
+++ b/toggl/endpoints.py
@@ -1,4 +1,4 @@
-V8_BASE_URL = "https://www.toggl.com/api/v8"
+V8_BASE_URL = "https://api.track.toggl.com/api/v8"
 
 
 class Endpoints(object):
@@ -7,12 +7,12 @@ class Endpoints(object):
     WORKSPACES = f"{V8_BASE_URL}/workspaces"
     CLIENTS = f"{V8_BASE_URL}/clients"
     PROJECTS = f"{V8_BASE_URL}/projects"
-    REPORT_DETAILED = "https://toggl.com/reports/api/v2/details"
-    REPORT_SUMMARY = "https://toggl.com/reports/api/v2/summary"
+    REPORT_DETAILED = "https://api.track.toggl.com/reports/api/v2/details"
+    REPORT_SUMMARY = "https://api.track.toggl.com/reports/api/v2/summary"
     START_TIME = f"{V8_BASE_URL}/time_entries/start"
     TIME_ENTRIES = f"{V8_BASE_URL}/time_entries"
     CURRENT_RUNNING_TIME = f"{V8_BASE_URL}/time_entries/current"
-    REPORT_WEEKLY = "https://toggl.com/reports/api/v2/weekly"
+    REPORT_WEEKLY = "https://api.track.toggl.com/reports/api/v2/weekly"
 
     @staticmethod
     def STOP_TIME(pid):


### PR DESCRIPTION
[Toggl documentation](https://github.com/toggl/toggl_api_docs/blob/master/README.md) mentions that

> Using the API from toggl.com or www.toggl.com will be dropped at The End of June 2021. Switch to api.track.toggl.com


I've just updated the base URL, gives the same results :)

Original base URL is still working even though it's now October, but I figured they could change it soon.

